### PR TITLE
Feat/tf-cloudwatch-event-trigger-state-machine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fest-vibes-ai-etl-pipeline"
-version = "0.0.16"
+version = "0.0.17"
 description = "ETL Pipeline for Festival and Events Data Processing"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
# Add Daily CloudWatch Event Trigger for ETL Pipeline

## Overview

Adds automated scheduling to run the ETL pipeline daily at 3 AM CST/CDT. Previously the Step Function had to be triggered manually - this enables automatic daily processing of New Orleans music events.

## Primary Changes

### CloudWatch Event Rule and Targeting

- **Daily Schedule**: `cron(0 8 * * ? *)` = 8 AM UTC = 3 AM CDT
  - Accounts for daylight saving time (CDT)
  - Triggers Step Function execution automatically
  - File location: `terraform/environments/prod/step-function.tf`

- **EventBridge IAM Role**: Allows CloudWatch Events to invoke Step Functions
  - Role: `fest-vibes-ai-eventbridge-step-function-role`
  - Policy: `states:StartExecution` permission on ETL pipeline
  - Proper service trust relationship for `events.amazonaws.com`

## Technical Improvements

### Infrastructure as Code

- **Pure Terraform Addition**: No code changes, only infrastructure
  - No Docker image rebuilds required
  - No application logic modifications
  - Safe to deploy with `terraform apply`

## Testing

- [ ] Terraform plan validates successfully
- [ ] IAM permissions are correctly configured
- [ ] CloudWatch Event rule syntax is valid
- [ ] Step Function can be invoked by EventBridge

## Files Changed

**Infrastructure Files:**
- `terraform/environments/prod/step-function.tf` - Added CloudWatch Event rule, target, and IAM resources

## Breaking Changes

None

## Migration Required

None - this is a pure infrastructure addition that enables automation without affecting existing functionality.