### PR TITLE
[Fix] Step Function for Cache Manager: Add Query Parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fest-vibes-ai-etl-pipeline"
-version = "0.0.18"
+version = "0.0.19"
 description = "ETL Pipeline for Festival and Events Data Processing"
 requires-python = ">=3.11"
 dependencies = [

--- a/terraform/environments/prod/step-function.tf
+++ b/terraform/environments/prod/step-function.tf
@@ -134,6 +134,9 @@ resource "aws_sfn_state_machine" "etl_pipeline" {
               Type = "Task"
               Resource = aws_lambda_function.cache_manager.arn
               Parameters = {
+                queryStringParameters = {
+                  "date.$" = "$.date"
+                }
                 "date.$" = "$.date"
                 "extractorData.$" = "$.state.extractorResult"
                 "loaderData.$" = "$.state.loaderResult"


### PR DESCRIPTION
# [Fix] Step Function for Cache Manager: Add Query Parameters

## Overview

If no queryparamters passed to cache manger, the date would default to today's date. This is not ideal, as the cache manager should be able to handle the date parameter, and we should have in redis a representation of events from today's sweep.

## Primary Changes

### [Main Feature]

- **Extend Parameters to the Cache Manager**
  - see terraform/environments/prod/step-function.tf